### PR TITLE
🎉 Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@6543, @CrimsonFez, @nicolas-r, @qwerty287, @tkikuchi2000, @ztelliot
+@6543, @CrimsonFez, @coralhl, @nicolas-r, @qwerty287, @tkikuchi2000, @ztelliot
 
 ### 💥 Breaking changes
 
@@ -39,6 +39,7 @@
 
 ### Misc
 
+- 🎉 Release 1.0.0 [[#1](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/1)]
 - Update pipeline to use lates buildx plugin [[#37](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/37)]
 - [pre-commit.ci] pre-commit autoupdate [[#33](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/33)]
 - Add CODEOWNERS [[#30](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/30)]


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `1.0.0` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [1.0.0](https://github.com/coralhl/woodpecker-kaniko-plugin/releases/tag/1.0.0) - 2024-10-01

### 💥 Breaking changes

- Add `dry-run` setting and docs.md [[#12](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/12)]
- Switch to Woodpecker Environment Variables [[#9](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/9)]

### ✨ Features

- Add insecure options [[#36](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/36)]
- Add support for docker hub mirrors and update image version [[#1](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/1)]

### 🐛 Bug Fixes

- Fix build arg [[#35](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/35)]
- Fix build arg quoting [[#31](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/31)]
- make plugin.sh executable again [[#23](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/23)]
- Fix release pipeline [[#7](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/7)]

### 📈 Enhancement

- Add two new options (--ignore-var-run and env_file), review the dry-run logic and try to fix some issues [[#20](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/20)]

### 📚 Documentation

- Fix author key [[#14](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/14)]

### 📦️ Dependency

- chore(deps): update woodpeckerci/plugin-ready-release-go docker tag to v2 [[#40](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/40)]
- bump kaniko to v1.22.0 [[#32](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/32)]
- chore(deps): update woodpeckerci/plugin-docker-buildx docker tag to v4 [[#28](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/28)]

### Misc

- 🎉 Release 1.0.0 [[#1](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/1)]
- Update pipeline to use lates buildx plugin [[#37](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/37)]
- [pre-commit.ci] pre-commit autoupdate [[#33](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/33)]
- Add CODEOWNERS [[#30](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/30)]
- chore(deps): update woodpeckerci/plugin-docker-buildx docker tag to v3 [[#22](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/22)]
- Use cleartext username [[#21](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/21)]
- chore(deps): update alpine docker tag to v3.19 [[#11](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/11)]
- Fix some more linting issues [[#5](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/5)]
- Init pipeline [[#3](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/3)]
- chore: Configure Renovate [[#2](https://github.com/coralhl/woodpecker-kaniko-plugin/pull/2)]